### PR TITLE
includes dockerfile for building and running with npm start and npm stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.DOCKERRUN

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM mhart/alpine-node:base-6
+
+WORKDIR /src
+ADD . .
+
+EXPOSE 1389
+CMD ["node", "index"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Install Node.js 5+, then start the server:
 npm install
 node index
 ```
+## Docker Usage
+
+install node_modules
+start the container
+stop the container
+
+```
+npm install
+npm start
+npm stop
+
+```
+
+
 
 This will start the LDAP server and allow users to bind and search.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "eslint-plugin-babel": "^3.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+	"prestart": "docker build -t auth0-ldap-endpoint .",
+	"start": "docker run -d -p 1389:1389 auth0-ldap-endpoint > '.DOCKERRUN'",
+	"stop": "AUTH0_UUID=$(cat .DOCKERRUN) && docker stop ${AUTH0_UUID}"
+
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
Dockerized auth0-ldap-endpoint with `alpine-node:base-6` image

To further humanize: `npm start` has prestart function to build container and start function to launch newly built container on port `:1389`. Additionally, `npm stop` will take UUID created from `docker run -d -p 1389:1389 ...` result and `docker stop UUID`.

Committer: Peyton McNully <me@peytonmcnully.com>