### PR TITLE
Use a Non Interactive Client to fetch an access_token via the Client Credentials Grant

### DIFF
--- a/lib/routes/search.js
+++ b/lib/routes/search.js
@@ -2,10 +2,13 @@ import ldap from 'ldapjs';
 import auth0 from 'auth0';
 import logger from '../logger';
 
-export default function(domain, token) {
+export default function(domain, clientId, clientSecret) {
   const client = new auth0.ManagementClient({
     domain: domain,
-    token: token
+    clientId: clientId,
+    clientSecret: clientSecret,
+    scope: "read:users",
+    audience: `https://${domain}/api/v2/`,
   });
 
   return function(req, res, next) {

--- a/server.js
+++ b/server.js
@@ -18,7 +18,12 @@ logger.info('Starting LDAP endpoint for Auth...');
 
 const server = ldap.createServer();
 server.bind('', authenticate(nconf.get('AUTH0_DOMAIN'), nconf.get('AUTH0_CLIENT_ID')));
-server.search('', requireAdministrator, search(nconf.get('AUTH0_DOMAIN'), nconf.get('AUTH0_API_TOKEN')));
+server.search('', requireAdministrator, search(
+  nconf.get('AUTH0_DOMAIN'),
+  nconf.get('AUTH0_CLIENT_ID'),
+  nconf.get('AUTH0_CLIENT_SECRET')
+));
+
 server.listen(nconf.get('LDAP_PORT'), () => {
   logger.info(`LDAP server listening on: ${server.url}`);
 });


### PR DESCRIPTION
This avoids having to obtain and renew  AUTH0_API_TOKEN out-of-band.